### PR TITLE
Add defensive assertions across task handling

### DIFF
--- a/src/main/java/bestie/Parser.java
+++ b/src/main/java/bestie/Parser.java
@@ -16,7 +16,12 @@ public class Parser {
      * @throws BestieException if the command is invalid or missing arguments
      */
     public boolean parse(String input, TaskList tasks, Ui ui, Storage storage) throws BestieException {
+        assert input != null : "Input command must not be null";
+        assert tasks != null : "Task list must not be null";
+        assert ui != null : "UI must not be null";
+        assert storage != null : "Storage must not be null";
         String[] parts = input.split(" ", 2);
+        assert parts.length > 0 : "Splitting the command should yield at least one token";
         String command = parts[0];
         switch (command) {
             case "bye":
@@ -36,6 +41,7 @@ public class Parser {
                     throw new BestieException("Please specify which task to mark!");
                 }
                 int markIndex = Integer.parseInt(parts[1]) - 1;
+                assert markIndex >= 0 && markIndex < tasks.size() : "Mark index must be within the task list";
                 Task markTask = tasks.get(markIndex);
                 markTask.markAsDone();
                 saveQuiet(storage, tasks);
@@ -46,6 +52,7 @@ public class Parser {
                     throw new BestieException("Please specify which task to unmark!");
                 }
                 int unmarkIndex = Integer.parseInt(parts[1]) - 1;
+                assert unmarkIndex >= 0 && unmarkIndex < tasks.size() : "Unmark index must be within the task list";
                 Task unmarkTask = tasks.get(unmarkIndex);
                 unmarkTask.markAsUndone();
                 saveQuiet(storage, tasks);
@@ -56,6 +63,7 @@ public class Parser {
                     throw new BestieException("Please specify which task to delete!");
                 }
                 int delIndex = Integer.parseInt(parts[1]) - 1;
+                assert delIndex >= 0 && delIndex < tasks.size() : "Delete index must be within the task list";
                 Task removed = tasks.remove(delIndex);
                 saveQuiet(storage, tasks);
                 ui.showDelete(removed, tasks.size());
@@ -74,6 +82,7 @@ public class Parser {
                     throw new BestieException("Deadline command must have a /by date/time!");
                 }
                 String[] deadlineParts = parts[1].split("/by", 2);
+                assert deadlineParts.length == 2 : "Deadline command must contain a description and a /by clause";
                 if (deadlineParts[0].trim().isEmpty() || deadlineParts[1].trim().isEmpty()) {
                     throw new BestieException("Deadline description and date/time cannot be empty!");
                 }
@@ -87,8 +96,10 @@ public class Parser {
                     throw new BestieException("Event must have /from and /to times!");
                 }
                 String[] eventParts = parts[1].split("/from", 2);
+                assert eventParts.length == 2 : "Event command must contain a description and a /from clause";
                 String descr = eventParts[0].trim();
                 String[] fromTo = eventParts[1].split("/to", 2);
+                assert fromTo.length == 2 : "Event command must contain both /from and /to clauses";
                 if (descr.isEmpty() || fromTo[0].trim().isEmpty() || fromTo[1].trim().isEmpty()) {
                     throw new BestieException("Event description and times cannot be empty!");
                 }

--- a/src/main/java/bestie/Storage.java
+++ b/src/main/java/bestie/Storage.java
@@ -30,6 +30,7 @@ public class Storage {
      * @param filePath location of the data file
      */
     public Storage(Path filePath) {
+        assert filePath != null : "Storage file path must not be null";
         this.filePath = filePath;
     }
 
@@ -71,6 +72,7 @@ public class Storage {
      * @throws IOException if writing fails
      */
     public void save(List<Task> tasks) throws IOException {
+        assert tasks != null : "Tasks to save must not be null";
         Path parent = filePath.getParent();
         if (parent != null) {
             Files.createDirectories(parent);
@@ -101,6 +103,7 @@ public class Storage {
      * </ul>
      */
     private Task parseLine(String line) throws BestieException {
+        assert line != null : "Line to parse must not be null";
         String[] parts = line.split("\\s*\\|\\s*");
         if (parts.length < 3) {
             throw new BestieException("Too few fields: " + line);

--- a/src/main/java/bestie/Task.java
+++ b/src/main/java/bestie/Task.java
@@ -15,6 +15,8 @@ public class Task {
      * @param type        type discriminator used for formatting and storage
      */
     public Task(String description, TaskType type) {
+        assert description != null : "Task description must not be null";
+        assert type != null : "Task type must not be null";
         this.description = description;
         this.status = Status.NOT_DONE;
         this.type = type;

--- a/src/main/java/bestie/TaskList.java
+++ b/src/main/java/bestie/TaskList.java
@@ -14,6 +14,7 @@ public class TaskList {
      * Creates an empty task list.
      */
     public TaskList() {
+        assert tasks != null : "Backing task list must not be null";
         this.tasks = new ArrayList<>();
     }
 
@@ -32,6 +33,7 @@ public class TaskList {
      * @param task task to add
      */
     public void add(Task task) {
+        assert tasks != null : "Backing task list must not be null";
         tasks.add(task);
     }
 
@@ -42,6 +44,7 @@ public class TaskList {
      * @return the removed task
      */
     public Task remove(int index) {
+        assert index >= 0 && index < tasks.size() : "Removal index must be within bounds";
         return tasks.remove(index);
     }
 
@@ -52,6 +55,7 @@ public class TaskList {
      * @return the task stored at that index
      */
     public Task get(int index) {
+        assert index >= 0 && index < tasks.size() : "Access index must be within bounds";
         return tasks.get(index);
     }
 
@@ -61,6 +65,7 @@ public class TaskList {
      * @param index position of the task to update
      */
     public void mark(int index) {
+        assert index >= 0 && index < tasks.size() : "Mark index must be within bounds";
         tasks.get(index).markAsDone();
     }
 
@@ -70,6 +75,7 @@ public class TaskList {
      * @param index position of the task to update
      */
     public void unmark(int index) {
+        assert index >= 0 && index < tasks.size() : "Unmark index must be within bounds";
         tasks.get(index).markAsUndone();
     }
 
@@ -98,6 +104,7 @@ public class TaskList {
      * @return ordered list of matching tasks
      */
     public List<Task> find(String keyword) {
+        assert keyword != null : "Search keyword must not be null";
         ArrayList<Task> matches = new ArrayList<>();
         String needle = keyword.toLowerCase();
         for (Task task : tasks) {


### PR DESCRIPTION
This keeps the assertions as lightweight documentation that only triggers when developers enable them, avoiding any runtime overhead in production builds.

Let's add explicit assert guards to surface violated assumptions immediately.